### PR TITLE
fix OOM for large video files, or larger FPS

### DIFF
--- a/code/inference.py
+++ b/code/inference.py
@@ -1,109 +1,106 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-import logging
-import json
-import torch 
-import numpy as np
-import torchvision.transforms as transforms
-from six import BytesIO
 import io
-from PIL import Image
-import cv2
+import json
+import logging
+import os
 import tempfile
 
+import cv2
+import torch
+import torchvision.transforms as transforms
 
-
+# This code will be loaded on each worker separately..
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 def model_fn(model_dir):
     device = get_device()
-    print('device is')
-    print(device)
+    logger.info(">>> Device is '%s'.." % device)
     model = torch.load(model_dir + '/model.pth', map_location=torch.device(device))
     print(type(model))
+    logger.info(">>> Model loaded!..")
     return model
 
+def transform_fn(model, request_body, content_type, accept):
+    interval = int(os.environ.get('FRAME_INTERVAL', 30))
+    frame_width = int(os.environ.get('FRAME_WIDTH', 1024))
+    frame_height = int(os.environ.get('FRAME_HEIGHT', 1024))
+    batch_size = int(os.environ.get('BATCH_SIZE', 24))
 
-def input_fn(request_body, request_content_type):
-    frame_width = 1024
-    frame_height = 1024
-    interval = 30
     f = io.BytesIO(request_body)
     tfile = tempfile.NamedTemporaryFile(delete=False)
     tfile.write(f.read())
-    print(tfile.name)
-    video_frames = video2frame(tfile,frame_width, frame_height, interval)  
-    #convert to tensor of float32 type
-    transform = transforms.Compose([
-        transforms.Lambda(lambda video_frames: torch.stack([transforms.ToTensor()(frame) for frame in video_frames])) # returns        a 4D tensor
-    ])
-    image_tensors = transform(video_frames)
 
-    return image_tensors
+    all_predictions = []
 
-def predict_fn(data, model):
-    print('in custom predict function')
+    for batch_frames in batch_generator(tfile, frame_width, frame_height, interval, batch_size):
+        batch_inputs = preprocess(batch_frames)  # returns 4D tensor
+        batch_outputs = predict(batch_inputs, model)
+        logger.info(">>> Length of batch predictions: %d" % len(batch_outputs))
+        batch_predictions = postprocess(batch_outputs)
+        all_predictions.extend(batch_predictions)
+    
+    logger.info(">>> Length of final predictions: %d" % len(all_predictions))
+    return json.dumps(all_predictions)
+
+def preprocess(inputs, preprocessor=transforms.ToTensor()):
+    outputs = torch.stack([preprocessor(frame) for frame in inputs])
+    return outputs
+    
+def predict(inputs, model):
+    logger.info(">>> Invoking model!..")
+
     with torch.no_grad():
         device = get_device()
         model = model.to(device)
-        input_data = data.to(device)
+        input_data = inputs.to(device)
         model.eval()
-        output = model(input_data)
-        
-    return output
+        outputs = model(input_data)
 
-    
-def output_fn(output_batch, accept='application/json'):
-    res = []
-    print('output list length')
-    print(len(output_batch))
-    for output in output_batch:
-         res.append({'boxes':output['boxes'].detach().cpu().numpy().tolist(),'labels':output['labels'].detach().cpu().numpy().tolist(),'scores':output['scores'].detach().cpu().numpy().tolist()})
-    
-    return json.dumps(res)
+    return outputs
+
+def postprocess(inputs):
+    outputs = []
+    for inp in inputs:
+        outputs.append({
+            'boxes': inp['boxes'].detach().cpu().numpy().tolist(),
+            'labels': inp['labels'].detach().cpu().numpy().tolist(),
+            'scores': inp['scores'].detach().cpu().numpy().tolist()
+        })
+    return outputs
 
 def get_device():
     device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
     return device
 
-
-def video2frame(
-    tfile,frame_width, frame_height, interval):
-    """
-    Extract frame from video by interval
-    :param video_src_path: video src path
-    :param video:　video file name
-    :param frame_width:　frame width
-    :param frame_height:　frame height
-    :param interval:　interval for frame to extract
-    :return:　list of numpy.ndarray 
-    """
-    video_frames = []
+def batch_generator(tfile, frame_width, frame_height, interval, batch_size):
     cap = cv2.VideoCapture(tfile.name)
     frame_index = 0
-    frame_count = 0
-    if cap.isOpened():
-        success = True
-    else:
-        success = False
-        print("Read failed!")
+    frame_buffer = []
 
-    while success:
+    while cap.isOpened():
+
         success, frame = cap.read()
 
+        if not success:
+            cap.release()
+            if frame_buffer:
+                yield frame_buffer
+            return
+
         if frame_index % interval == 0:
-            print("---> Reading the %d frame:" % frame_index, success)
-            resize_frame = cv2.resize(
-                frame, (frame_width, frame_height), interpolation=cv2.INTER_AREA
-            )
-            video_frames.append(resize_frame)
-            frame_count += 1
+            frame_resized = cv2.resize(frame, (frame_width, frame_height), interpolation=cv2.INTER_AREA)
+            frame_buffer.append(frame_resized)
+
+        if len(frame_buffer) == batch_size:
+            yield frame_buffer
+            frame_buffer.clear()
 
         frame_index += 1
+    else:
+        raise Exception("Failed to open video '%s'!.." % tfile.name)
 
-    cap.release()
-    print('Number of frames')
-    print(frame_count)
-    return video_frames
+


### PR DESCRIPTION
*Description of changes:*
Changes in code reflect the updated blog: https://aws.amazon.com/blogs/machine-learning/run-computer-vision-inference-on-large-videos-with-amazon-sagemaker-asynchronous-endpoints/

*Summary:*
This PR reflects the edits to the published launch blog for SageMaker Asynchronous Inference (https://aws.amazon.com/blogs/machine-learning/run-computer-vision-inference-on-large-videos-with-amazon-sagemaker-asynchronous-endpoints/) and follows generator-based approach to enable inference on video payloads of longer duration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
